### PR TITLE
mmc: msm_sdcc: Remove unnecessary delay in interrupt context

### DIFF
--- a/drivers/mmc/host/msm_sdcc.c
+++ b/drivers/mmc/host/msm_sdcc.c
@@ -496,8 +496,6 @@ msmsdcc_request_end(struct msmsdcc_host *host, struct mmc_request *mrq)
 
 	if (mrq->data)
 		mrq->data->bytes_xfered = host->curr.data_xfered;
-	if (mrq->cmd->error == -ETIMEDOUT)
-		mdelay(5);
 
 	msmsdcc_reset_dpsm(host);
 


### PR DESCRIPTION
msmsdcc_request_end when called with interrupts disabled inside an
interrupt handler adds an unnecessary 5ms delay on command timeouts,
which impacts system performance. Remove this delay.

Change-Id: I90aec109fe84f7b9f9a9362b5ee2d8d1310833af
Signed-off-by: Venkat Gopalakrishnan <venkatg@codeaurora.org>